### PR TITLE
15 a fix postgre docker compose build error

### DIFF
--- a/postgreSQL/init.sql
+++ b/postgreSQL/init.sql
@@ -1,6 +1,3 @@
--- ============================================================
--- DROP TABLES (child → parent)
--- ============================================================
 DROP TABLE IF EXISTS company_file CASCADE;
 DROP TABLE IF EXISTS company_embedding CASCADE;
 DROP TABLE IF EXISTS company_bookmark CASCADE;
@@ -13,10 +10,10 @@ DROP TABLE IF EXISTS disclosure_file CASCADE;
 DROP TABLE IF EXISTS disclosure_list CASCADE;
 DROP TABLE IF EXISTS financial_account CASCADE;
 DROP TABLE IF EXISTS financial_index CASCADE;
-
--- legacy tables to clean out
 DROP TABLE IF EXISTS company CASCADE;
 DROP TABLE IF EXISTS user_account CASCADE;
+
+CREATE EXTENSION IF NOT EXISTS vector;
 
 
 -- ============================================================


### PR DESCRIPTION
## 문제
docker compose 실행 시 PostgreSQL 초기 스키마 생성 과정에서 아래 오류 발생:

ERROR: type "vector" does not exist

## 원인
- init.sql에서 `VECTOR` 컬럼을 생성하기 전에 `CREATE EXTENSION vector;` 구문이 없었음
- 기존 docker volume(`postgres_data`)이 이미 생성된 상태여서 init.sql이 재실행되지 않음

## 해결 내용
- init.sql 최상단에 `CREATE EXTENSION IF NOT EXISTS vector;` 추가
- `docker compose down -v` 명령으로 기존 volume 제거 후 재실행하도록 가이드

## 실행 방법
docker compose down -v
docker compose up --build

